### PR TITLE
Add a getFinite method to handle situations where the passed value is a non finite number (NaN, Infinity, etc.)

### DIFF
--- a/src/lodash-addons.js
+++ b/src/lodash-addons.js
@@ -425,6 +425,30 @@
     }
 
     /**
+     * Returns value if a finite number, otherwise a default number.
+     *
+     * @static
+     * @memberOf _
+     * @category Lang
+     * @param {mixed} value Source value
+     * @param {number} replacement Custom default if value is invalid type.
+     * @return {number} Final number.
+     * @example
+     *
+     * _.getFinite('')
+     * // => 0
+     *
+     * _.getFinite('', 100)
+     * // => 100
+     *
+     * _.getFinite(NaN,25)
+     * // => 25
+     */
+    function getFinite(value, replacement) {
+        return baseGetType(_.isFinite, 0, value, replacement);
+    }
+
+    /**
      * Returns value if a string, otherwise a default string.
      *
      * @static
@@ -971,6 +995,7 @@
         getBoolean: getBoolean,
         getFunction: getFunction,
         getNumber: getNumber,
+        getFinite: getFinite,
         getObject: getObject,
         getString: getString,
         getPrototype: getPrototype,


### PR DESCRIPTION
I'm dealing with the situation where the value I want to check is read by _.toInteger from a String. This method return NaN, that is a Number (_.isNumber return true), but is not exactly what I'm looking for.
This new method should be able to handle these situation using as validator the _.isFinite instead